### PR TITLE
Fix #481 & Cli enhancements

### DIFF
--- a/app/Console/Commands/Environment/AppSettingsCommand.php
+++ b/app/Console/Commands/Environment/AppSettingsCommand.php
@@ -37,6 +37,7 @@ class AppSettingsCommand extends Command
                             {--session= : The session driver backend to use.}
                             {--queue= : The queue driver backend to use.}
                             {--redis-host= : Redis host to use for connections.}
+                            {--redis-user= : User used to connect to redis.}
                             {--redis-pass= : Password used to connect to redis.}
                             {--redis-port= : Port to connect to redis over.}
                             {--settings-ui= : Enable or disable the settings UI.}';
@@ -154,6 +155,23 @@ class AppSettingsCommand extends Command
 
         if (empty($this->variables['REDIS_PASSWORD'])) {
             $this->variables['REDIS_PASSWORD'] = 'null';
+        }
+
+        $askForRedisUser = true;
+        if (!empty(config('database.redis.default.username'))) {
+            $this->variables['REDIS_USERNAME'] = config('database.redis.default.username');
+            $askForRedisUser = $this->confirm('It seems a user is already defined for Redis, would you like to change it?');
+        }
+
+        if ($askForRedisUser) {
+            $this->output->comment(__('commands.appsettings.redis.comment'));
+            $this->variables['REDIS_USERNAME'] = $this->option('redis-user') ?? $this->output->askHidden(
+                'Redis User'
+            );
+        }
+
+        if (empty($this->variables['REDIS_USERNAME'])) {
+            $this->variables['REDIS_USERNAME'] = 'null';
         }
 
         $this->variables['REDIS_PORT'] = $this->option('redis-port') ?? $this->ask(

--- a/app/Console/Commands/InfoCommand.php
+++ b/app/Console/Commands/InfoCommand.php
@@ -136,7 +136,7 @@ class InfoCommand extends Command
             ['Domain', $this->sanitize(env('SESSION_DOMAIN'))],
             ['Path', env('SESSION_PATH')],
             ['Encrypt', env('SESSION_ENCRYPT') ? 'Yes' : $this->formatText('No', 'bg=red')],
-            ['Secure', env('SESSION_SECURE_COOKIE') ? 'Yes' : $this->formatText('No', 'bg=red')]
+            ['Secure', env('SESSION_SECURE_COOKIE') ? 'Yes' : $this->formatText('No', 'bg=red')],
         ], 'compact');
 
         $this->output->title('Features Configuration');

--- a/app/Console/Commands/InfoCommand.php
+++ b/app/Console/Commands/InfoCommand.php
@@ -3,13 +3,15 @@
 namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Str;
 use App\Services\Helpers\SoftwareVersionService;
 
 class InfoCommand extends Command
 {
-    protected $description = 'Displays the application, database, email and backup configurations along with the panel version.';
+    protected $signature = 'p:info
+        {--secret : Prints every info.}';
 
-    protected $signature = 'p:info';
+    protected $description = 'Displays the application, database, email and backup configurations along with the panel version.';
 
     /**
      * InfoCommand constructor.
@@ -35,67 +37,132 @@ class InfoCommand extends Command
         $this->table([], [
             ['Environment', config('app.env') === 'production' ? config('app.env') : $this->formatText(config('app.env'), 'bg=red')],
             ['Debug Mode', config('app.debug') ? $this->formatText('Yes', 'bg=red') : 'No'],
-            ['Application Name', config('app.name')],
-            ['Application URL', config('app.url')],
+            ['Secure', request()->isSecure() ? 'Yes' : $this->formatText('No', 'bg=red')],
             ['Installation Directory', base_path()],
+            [' '],
+            ['Key', env('APP_KEY') === '' ? $this->formatText('Not generated yet', 'bg=red') : $this->sanitize()],
+            ['TimeZone', config('app.timezone')],
+            ['Locale', config('app.locale')],
+            // ['Theme', config('app.theme')],
+            ['Name', $this->sanitize(config('app.name'))],
+            ['URL', $this->sanitize(config('app.url'))],
+            [' '],
             ['Cache Driver', config('cache.default')],
             ['Queue Driver', config('queue.default') === 'sync' ? $this->formatText(config('queue.default'), 'bg=red') : config('queue.default')],
             ['Session Driver', config('session.driver')],
             ['Filesystem Driver', config('filesystems.default')],
+
         ], 'compact');
 
         $this->output->title('Database Configuration');
         $driver = config('database.default');
-        if ($driver === 'sqlite') {
-            $this->table([], [
-                ['Driver', $driver],
-                ['Database', config("database.connections.$driver.database")],
-            ], 'compact');
-        } else {
-            $this->table([], [
-                ['Driver', $driver],
-                ['Host', config("database.connections.$driver.host")],
+        $sqlConfig = [
+            ['Driver', $driver],
+            ['Database', config("database.connections.$driver.database")],
+        ];
+
+        if ($driver !== 'sqlite') {
+            array_push($sqlConfig,
+                ['Host', $this->sanitize(config("database.connections.$driver.host"))],
                 ['Port', config("database.connections.$driver.port")],
-                ['Database', config("database.connections.$driver.database")],
                 ['Username', config("database.connections.$driver.username")],
-            ], 'compact');
+            );
         }
+
+        $this->table([], $sqlConfig, 'compact');
+
+        $this->output->title('Redis Configuration');
+
+        $this->table([], [
+            ['Enabled', env('REDIS_HOST') === '' ? 'No' : 'Yes'],
+            ['Host', $this->sanitize(env('REDIS_HOST'))],
+            ['Port', env('REDIS_PORT')],
+            ['User', env('REDIS_USER')],
+        ], 'compact');
 
         $this->output->title('Email Configuration');
         $driver = config('mail.default');
+        $mailConfig = [
+            ['Driver', $driver],
+            ['From Address', $this->sanitize(config('mail.from.address'))],
+            ['From Name', $this->sanitize(config('mail.from.name'))],
+            [$this->formatText('Notifications', 'bg=yellow')],
+            ['Send Install', config('mail.send_install_notification') ? 'Yes' : 'No'],
+            ['Send Reinstall', config('mail.send_reinstall_notification') ? 'Yes' : 'No'],
+        ];
+
         if ($driver === 'smtp') {
-            $this->table([], [
+            array_splice($mailConfig, 1, 0, [
                 ['Driver', $driver],
-                ['Host', config("mail.mailers.$driver.host")],
+                ['Host', $this->sanitize(config("mail.mailers.$driver.host"))],
                 ['Port', config("mail.mailers.$driver.port")],
-                ['Username', config("mail.mailers.$driver.username")],
+                ['Username', $this->sanitize(config("mail.mailers.$driver.username"))],
                 ['Encryption', config("mail.mailers.$driver.encryption")],
-                ['From Address', config('mail.from.address')],
-                ['From Name', config('mail.from.name')],
-            ], 'compact');
-        } else {
-            $this->table([], [
-                ['Driver', $driver],
-                ['From Address', config('mail.from.address')],
-                ['From Name', config('mail.from.name')],
-            ], 'compact');
+                ['From Address', $this->sanitize(config('mail.from.address'))],
+                ['From Name', $this->sanitize(config('mail.from.name'))],
+            ]);
         }
+
+        $this->table([], $mailConfig, 'compact');
 
         $this->output->title('Backup Configuration');
         $driver = config('backups.default');
+        $backupConfig = [
+            ['Driver', $driver],
+        ];
+
         if ($driver === 's3') {
-            $this->table([], [
-                ['Driver', $driver],
+            array_push($backupConfig,
                 ['Region', config("backups.disks.$driver.region")],
                 ['Bucket', config("backups.disks.$driver.bucket")],
-                ['Endpoint', config("backups.disks.$driver.endpoint")],
+                ['Endpoint', $this->sanitize(config("backups.disks.$driver.endpoint"))],
                 ['Use path style endpoint', config("backups.disks.$driver.use_path_style_endpoint") ? 'Yes' : 'No'],
-            ], 'compact');
-        } else {
-            $this->table([], [
-                ['Driver', $driver],
-            ], 'compact');
+                ['Use accelerate endpoint', config("backups.disks.$driver.use_accelerate_endpoint") ? 'Yes' : 'No'],
+                ['Storage class', config("backups.disks.$driver.storage_class")],
+            );
         }
+        $this->table([], $backupConfig, 'compact');
+
+        $this->output->title('Recaptcha Configuration');
+        $this->table([], [
+            ['Enabled', config('recaptcha.enabled') ? 'Yes' : $this->formatText('No', 'bg=red')],
+            ['Domain', config('recaptcha.domain')],
+            ['Secret Key', config('recaptcha.secret_key') == config('recaptcha._shipped_secret_key') ? $this->formatText('Default', 'bg=red') : 'Custom'],
+            ['Website Key', config('recaptcha.website_key') == config('recaptcha._shipped_website_key') ? $this->formatText('Default', 'bg=red') : 'Custom'],
+        ], 'compact');
+
+        $this->output->title('Session Configuration');
+        $this->table([], [
+            ['Domain', $this->sanitize(env('SESSION_DOMAIN'))],
+            ['Path', env('SESSION_PATH')],
+            ['Encrypt', env('SESSION_ENCRYPT') ? 'Yes' : $this->formatText('No', 'bg=red')],
+            ['Secure', env('SESSION_SECURE_COOKIE') ? 'Yes' : $this->formatText('No', 'bg=red')]
+        ], 'compact');
+
+        $this->output->title('Features Configuration');
+        $this->table([], [
+            [$this->formatText('Databases', 'bg=yellow')],
+            ['Enabled', config('client_features.databases.enabled') ? 'Yes' : $this->formatText('No', 'bg=red')],
+            ['Allow Random', config('client_features.databases.allow_random') ? 'Yes' : 'No'],
+            [$this->formatText('Schedules', 'bg=yellow')],
+            ['Per Schedule task limit', config('client_features.schedules.per_schedule_task_limit')],
+            [$this->formatText('Auto Allocations', 'bg=yellow')],
+            ['Enabled', config('allocations.enabled') ? 'Yes' : $this->formatText('No', 'bg=red')],
+            ['Range Start', config('allocations.range_start')],
+            ['Range End', config('allocations.range_end')],
+            [$this->formatText('Others', 'bg=yellow')],
+            ['Top Navigation', config('filament.top-navigation') ? 'Yes' : 'No'],
+            ['Use binary prefix', config('use_binary_prefix') ? 'MiB' : 'MB'],
+        ], 'compact');
+
+        $this->output->title('Logs Configuration');
+        $this->table([], [
+            ['Level', env('LOG_LEVEL')],
+            ['Channel', env('LOG_CHANNEL')],
+            ['Stack', env('LOG_STACK')],
+            ['Deprecations Channel', env('LOG_DEPRECATIONS_CHANNEL')],
+        ], 'compact');
+
     }
 
     /**
@@ -104,5 +171,23 @@ class InfoCommand extends Command
     private function formatText(string $value, string $opts = ''): string
     {
         return sprintf('<%s>%s</>', $opts, $value);
+    }
+
+    /**
+     * Format output to anonymize informations.
+     */
+    private function sanitize(?string $value = ''): string
+    {
+        if (!$this->option('secret')) {
+            return $value ?? '';
+        }
+
+        if (Str::startsWith($value, 'http')) {
+            $value = 'http' . (Str::startsWith($value, 'https://') ? 's' : '') . '://REDACTED';
+        } else {
+            $value = 'REDACTED';
+        }
+
+        return sprintf('%s', $value);
     }
 }

--- a/app/Console/Commands/Node/MakeNodeCommand.php
+++ b/app/Console/Commands/Node/MakeNodeCommand.php
@@ -10,7 +10,6 @@ class MakeNodeCommand extends Command
     protected $signature = 'p:node:make
                             {--name= : A name to identify the node.}
                             {--description= : A description to identify the node.}
-                            {--locationId= : A valid locationId.}
                             {--fqdn= : The domain name (e.g node.example.com) to be used for connecting to the daemon. An IP address may only be used if you are not using SSL for this node.}
                             {--public= : Should the node be public or private? (public=1 / private=0).}
                             {--scheme= : Which scheme should be used? (Enable SSL=https / Disable SSL=http).}

--- a/app/Console/Commands/Node/NodeConfigurationCommand.php
+++ b/app/Console/Commands/Node/NodeConfigurationCommand.php
@@ -8,17 +8,17 @@ use Illuminate\Console\Command;
 class NodeConfigurationCommand extends Command
 {
     protected $signature = 'p:node:configuration
-                            {node : The ID or UUID of the node to return the configuration for.}
+                            {--node= : The ID or UUID of the node to return the configuration for.}
                             {--format=yaml : The output format. Options are "yaml" and "json".}';
 
     protected $description = 'Displays the configuration for the specified node.';
 
     public function handle(): int
     {
-        $column = ctype_digit((string) $this->argument('node')) ? 'id' : 'uuid';
+        $column = ctype_digit((string) $this->option('node')) ? 'id' : 'uuid';
 
         /** @var \App\Models\Node $node */
-        $node = Node::query()->where($column, $this->argument('node'))->firstOr(function () {
+        $node = Node::query()->where($column, $this->option('node'))->firstOr(function () {
             $this->error(__('commands.node_config.error_not_exist'));
 
             exit(1);

--- a/app/Console/Commands/User/DeleteUserCommand.php
+++ b/app/Console/Commands/User/DeleteUserCommand.php
@@ -18,7 +18,7 @@ class DeleteUserCommand extends Command
         Assert::notEmpty($search, 'Search term should be an email address, got: %s.');
 
         $results = User::query()
-            ->where('id', 'LIKE', "$search%")
+            ->where('id', 'LIKE', "$search")
             ->orWhere('username', 'LIKE', "$search%")
             ->orWhere('email', 'LIKE', "$search%")
             ->get();
@@ -53,7 +53,7 @@ class DeleteUserCommand extends Command
         }
 
         if ($this->confirm(trans('command/messages.user.confirm_delete')) || !$this->input->isInteractive()) {
-            $user = User::query()->findOrFail($deleteUser);
+            $user = User::query()->findOrFail($deleteUser->id);
             $user->delete();
 
             $this->info(trans('command/messages.user.deleted'));

--- a/app/Console/Commands/User/DisableTwoFactorCommand.php
+++ b/app/Console/Commands/User/DisableTwoFactorCommand.php
@@ -3,32 +3,74 @@
 namespace App\Console\Commands\User;
 
 use App\Models\User;
+use Webmozart\Assert\Assert;
 use Illuminate\Console\Command;
 
 class DisableTwoFactorCommand extends Command
 {
     protected $description = 'Disable two-factor authentication for a specific user in the Panel.';
 
-    protected $signature = 'p:user:disable2fa {--email= : The email of the user to disable 2-Factor for.}';
+    protected $signature = 'p:user:disable2fa {--user=}';
 
     /**
      * Handle command execution process.
      *
      * @throws \App\Exceptions\Model\DataValidationException
      */
-    public function handle(): void
+    public function handle(): int
     {
         if ($this->input->isInteractive()) {
             $this->output->warning(trans('command/messages.user.2fa_help_text'));
         }
 
-        $email = $this->option('email') ?? $this->ask(trans('command/messages.user.ask_email'));
+        $search = $this->option('user') ?? $this->ask(trans('command/messages.user.search_users'));
+        Assert::notEmpty($search, 'Search term should be an email address, got: %s.');
+        $results = User::query()
+            ->where('id', 'LIKE', "$search%")
+            ->orWhere('username', 'LIKE', "$search%")
+            ->orWhere('email', 'LIKE', "$search%")
+            ->get();
 
-        $user = User::query()->where('email', $email)->firstOrFail();
-        $user->use_totp = false;
-        $user->totp_secret = null;
-        $user->save();
+        if (count($results) < 1) {
+            $this->error(trans('command/messages.user.no_users_found'));
+            if ($this->input->isInteractive()) {
+                return $this->handle();
+            }
+            return 1;
+        }
 
-        $this->info(trans('command/messages.user.2fa_disabled', ['email' => $user->email]));
+        if ($this->input->isInteractive()) {
+            $tableValues = [];
+            foreach ($results as $user) {
+                $tableValues[] = [$user->id, $user->email, $user->name, $user->use_totp ? 'enabled' : 'disabled'];
+            }
+
+            $this->table(['User ID', 'Email', 'Name', '2fa'], $tableValues);
+            if (!$disable2faUser = $this->ask(trans('command/messages.user.select_search_user'))) {
+                return $this->handle();
+            }
+        } else {
+            if (count($results) > 1) {
+                $this->error(trans('command/messages.user.multiple_found'));
+
+                return 1;
+            }
+
+            $disable2faUser = $results->first();
+        }
+
+        if ($this->confirm(trans('command/messages.user.2fa_confirm_disable')) || !$this->input->isInteractive()) {
+            $user = User::query()->findOrFail($disable2faUser->id);
+            $user->use_totp = false;
+            $user->totp_secret = null;
+            $user->save();
+
+            $this->info(trans('command/messages.user.2fa_disabled'));
+            if ($this->input->isInteractive()) {
+                $this->table(['User ID', 'Email', 'Name', '2fa'], [[$user->id, $user->email, $user->name, 'disabled']]);
+            }
+        }
+
+        return 0;
     }
 }

--- a/app/Console/Commands/User/DisableTwoFactorCommand.php
+++ b/app/Console/Commands/User/DisableTwoFactorCommand.php
@@ -26,7 +26,7 @@ class DisableTwoFactorCommand extends Command
         $search = $this->option('user') ?? $this->ask(trans('command/messages.user.search_users'));
         Assert::notEmpty($search, 'Search term should be an email address, got: %s.');
         $results = User::query()
-            ->where('id', 'LIKE', "$search%")
+            ->where('id', 'LIKE', "$search")
             ->orWhere('username', 'LIKE', "$search%")
             ->orWhere('email', 'LIKE', "$search%")
             ->get();

--- a/app/Console/Commands/User/MakeUserCommand.php
+++ b/app/Console/Commands/User/MakeUserCommand.php
@@ -11,7 +11,12 @@ class MakeUserCommand extends Command
 {
     protected $description = 'Creates a user on the system via the CLI.';
 
-    protected $signature = 'p:user:make {--email=} {--username=} {--password=} {--admin=} {--no-password}';
+    protected $signature = 'p:user:make
+        {--email=}
+        {--username=}
+        {--password=}
+        {--admin=}
+        {--no-password}';
 
     /**
      * MakeUserCommand constructor.
@@ -37,7 +42,7 @@ class MakeUserCommand extends Command
             return 1;
         }
 
-        $root_admin = $this->option('admin') ?? $this->confirm(trans('command/messages.user.ask_admin'));
+        $root_admin = is_null($this->option('admin')) ? $this->confirm(trans('command/messages.user.ask_admin')) : in_array(strtolower($this->option('admin')), ["yes", "y", "1"]);
         $email = $this->option('email') ?? $this->ask(trans('command/messages.user.ask_email'));
         $username = $this->option('username') ?? $this->ask(trans('command/messages.user.ask_username'));
 

--- a/app/Console/Commands/User/MakeUserCommand.php
+++ b/app/Console/Commands/User/MakeUserCommand.php
@@ -42,7 +42,7 @@ class MakeUserCommand extends Command
             return 1;
         }
 
-        $root_admin = is_null($this->option('admin')) ? $this->confirm(trans('command/messages.user.ask_admin')) : in_array(strtolower($this->option('admin')), ["yes", "y", "1"]);
+        $root_admin = is_null($this->option('admin')) ? $this->confirm(trans('command/messages.user.ask_admin')) : in_array(strtolower($this->option('admin')), ['yes', 'y', '1']);
         $email = $this->option('email') ?? $this->ask(trans('command/messages.user.ask_email'));
         $username = $this->option('username') ?? $this->ask(trans('command/messages.user.ask_username'));
 

--- a/lang/en/command/messages.php
+++ b/lang/en/command/messages.php
@@ -3,11 +3,11 @@
 return [
     'user' => [
         'search_users' => 'Enter a Username, User ID, or Email Address',
-        'select_search_user' => 'ID of user to delete (Enter \'0\' to re-search)',
+        'select_search_user' => 'ID of user (Enter \'0\' to re-search)',
         'deleted' => 'User successfully deleted from the Panel.',
         'confirm_delete' => 'Are you sure you want to delete this user from the Panel?',
         'no_users_found' => 'No users were found for the search term provided.',
-        'multiple_found' => 'Multiple accounts were found for the user provided, unable to delete a user because of the --no-interaction flag.',
+        'multiple_found' => 'Multiple accounts were found for the user provided, unable to proform the action on a user because of the --no-interaction flag.',
         'ask_admin' => 'Is this user an administrator?',
         'ask_email' => 'Email Address',
         'ask_username' => 'Username',
@@ -20,7 +20,8 @@ return [
             'This command will disable 2-factor authentication for a user\'s account if it is enabled. This should only be used as an account recovery command if the user is locked out of their account.',
             'If this is not what you wanted to do, press CTRL+C to exit this process.',
         ],
-        '2fa_disabled' => '2-Factor authentication has been disabled for :email.',
+        '2fa_disabled' => '2-Factor authentication has been disabled for',
+        '2fa_confirm_disable' => 'Are you sure you want to disable 2fa for this user from the Panel?',
     ],
     'schedule' => [
         'output_line' => 'Dispatching job for first task in `:schedule` (:id).',

--- a/lang/en/commands.php
+++ b/lang/en/commands.php
@@ -10,7 +10,7 @@ return [
         ],
         'redis' => [
             'note' => 'You\'ve selected the Redis driver for one or more options, please provide valid connection information below. In most cases you can use the defaults provided unless you have modified your setup.',
-            'comment' => 'By default a Redis server instance has no password as it is running locally and inaccessible to the outside world. If this is the case, simply hit enter without entering a value.',
+            'comment' => 'By default a Redis server instance has no user and no password as it is running locally and inaccessible to the outside world. If this is the case, simply hit enter without entering a value.',
         ],
     ],
     'database_settings' => [


### PR DESCRIPTION
- [ ✅ ] Add missing entried in `p:info` & implement `--secret` option, without it all sensitve information will be censored (Quite useful for helping others that don't want to leak their ip/domain on discord) 
- [ ✅ ] Add missing redis username in `p:environment:setup`

- [ ✅ ] Allow user search using id,email ,username in `p:user:disable2fa`
- [ ✅ ] Make search user by id not use wildcard in `p:user:*`
- [ ✅ ] Re remove locationId ([again](<https://github.com/pelican-dev/panel/commit/276b51f47731ad7b7c03155cf2a8478e22e8bc87#diff-77b2699b2d08fa8cc60ad28c78b2616ad6bb72aba2409f9456219ecff5d9d2ee>))

- [ ✅ ] Make node an option and not an argument to follow code style in `p:node:configuration`

- [ 🔳 ] Figure out why tf does $user become a string when using interactive mode in `p:user:*`

- [ 🔳 ] Reset --user if the one given doesn't exist to avoid indefinitely searching the same non existing user in `p:user:*` 

- [ 🔳 ] Refactor foreach to map in `p:user:*`

- [ 🔳 ] Remake `p:upgrade` command to use patch instead of curl&tar

- [ 🔳 ] Allow for quick fix `p:upgrade --patch=dbc164f` (commit) or `p:upgrade --patch=5` (pr)